### PR TITLE
Add nested table collapse feature

### DIFF
--- a/js/editor/events.js
+++ b/js/editor/events.js
@@ -145,6 +145,16 @@ $('#btnToggleMeta').onclick = () => {
     (state.currentView==='flat'?$('#btnBuildFlat'):$('#btnBuild')).click();
   };
 
+  /* ----- ネストテーブル開閉 ----- */
+  state.dataZone.addEventListener('click', e => {
+    const th = e.target.closest('th.collapsible');
+    if(!th) return;
+    const td = th.nextElementSibling;
+    if(!td) return;
+    const collapsed = th.classList.toggle('collapsed');
+    td.style.display = collapsed ? 'none' : '';
+  });
+
   /* --- メタ側 --- */
   $('#btnMetaBuildFlat').onclick = () => {
     state.metaZone.textContent='';

--- a/js/editor/render.js
+++ b/js/editor/render.js
@@ -26,6 +26,7 @@ function renderDataNode(node,dataObj){
   const tr=document.createElement('tr');
   const th=document.createElement('th');
   th.textContent=node.label;
+  th.classList.add('collapsible');
 
   const td=document.createElement('td');
   td.classList.add('no-alt');

--- a/js/js/editor/events.js
+++ b/js/js/editor/events.js
@@ -57,6 +57,16 @@ export function initEditor(){
     (state.currentView==='flat'?$('#btnBuildFlat'):$('#btnBuild')).click();
   };
 
+  /* ----- ネストテーブル開閉 ----- */
+  state.dataZone.addEventListener('click', e => {
+    const th = e.target.closest('th.collapsible');
+    if(!th) return;
+    const td = th.nextElementSibling;
+    if(!td) return;
+    const collapsed = th.classList.toggle('collapsed');
+    td.style.display = collapsed ? 'none' : '';
+  });
+
   /* --- メタ側 --- */
   $('#btnMetaBuildFlat').onclick = () => {
     state.metaZone.textContent='';

--- a/js/js/editor/render.js
+++ b/js/js/editor/render.js
@@ -26,6 +26,7 @@ function renderDataNode(node,dataObj){
   const tr=document.createElement('tr');
   const th=document.createElement('th');
   th.textContent=node.label;
+  th.classList.add('collapsible');
 
   const td=document.createElement('td');
   td.classList.add('no-alt');

--- a/style.css
+++ b/style.css
@@ -218,6 +218,11 @@ table.nested td{
   border:1px solid #555;
 }
 
+/* 折りたたみ可能カラムヘッダ */
+th.collapsible{cursor:pointer}
+th.collapsible::before{content:'\25bc\20'} /* ▼ */
+th.collapsible.collapsed::before{content:'\25b6\20'} /* ▶ */
+
 /* メタテーブル専用色 */
 table.meta thead th{background:#3a3a3a}
 


### PR DESCRIPTION
## Summary
- add collapsible header rows so nested tables can be toggled
- wire up click handler for the collapsible headers
- style the collapsible headers with open/closed icons

## Testing
- `git status --short`